### PR TITLE
Add Ecommerce Profit Tracker PRO to Accounting & Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ This is a curated list about tools for everything from productivity to hosting t
 ### Accounting & Finance
 - Wave Apps - https://www.waveapps.com
 - Odoo Accounting - https://www.odoo.com/app/accounting
+- Ecommerce Profit Tracker PRO - https://whop.com/glm-643b/ecommerce-profit-tracker-pro-know-your-real-profit
 
 ### CRM:
 - HubSpot CRM - https://www.hubspot.com/products/crm


### PR DESCRIPTION
## What

Adds **Ecommerce Profit Tracker PRO** to the Accounting & Finance section, right after Odoo Accounting.

## Why it fits

This section currently lists Wave Apps and Odoo Accounting as finance tools for startups. Ecommerce Profit Tracker PRO is a complementary finance tool for a specific segment of startup founders — those selling on Etsy, Shopify, Amazon, or eBay. It's a one-time $19 Excel/Google Sheets workbook that calculates true net profit per order (after marketplace fees, ad spend, COGS, shipping), filling the "ecommerce-specific finance" gap next to the general-purpose accounting entries.

Following the existing list style: `- Name - URL`.

I built this product myself, non-affiliate. Happy to adjust wording if needed. Thanks for curating this list!