### PR TITLE
Add One Person Company

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Substack - https://substack.com
 - Medium - https://medium.com
 - Dev.to - https://dev.to
+- One Person Company - https://onepersoncompany.com (free skill guides, SEO playbook & AI tool comparisons for solo founders)
 
 ## Productivity, Management, Organization
 


### PR DESCRIPTION
Adds **[One Person Company](https://onepersoncompany.com)** to the **Blogging, Writing** section.

It's a free resource hub for solo founders and one-person businesses: **317 actionable skill guides**, a complete **SEO playbook**, and **AI tool comparisons** — all focused on growing a business without hiring a team.

It fits this list because it's a free writing/skill resource for early founders.

Thanks for curating this list!