### PR TITLE
Add cv.cm/v (AI video) to Video making

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ Good for team projects
 - Video captions - https://subsvideo.com
 - VEED - https://www.veed.io
 - Tavus (AI based) - https://www.tavus.io
+- cv.cm/v (AI based, queue-free Seedance 2.0 text/image-to-video, free credits) - https://cv.cm/v
 
 ### Stock Photos/Illustrations/Icons:
 - Unsplash - https://unsplash.com


### PR DESCRIPTION
Adds **[cv.cm/v](https://cv.cm/v)** to the Video making list under Graphics, Design, and Media (tagged `AI based`, matching the existing Tavus entry).

cv.cm/v is a web AI studio offering queue-free, full-power **Seedance 2.0** text-to-video / image-to-video, plus AI image generation and a REST API. It runs on its own custom domain, no signup is required to try it, and new users get 100 free credits.

One line added, matching the existing `- Name - https://url` format.