### PR TITLE
Add free website speed comparison tool to Site Performance Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Google Page Insight	https://developers.google.com/speed/pagespeed/insights
 - Web Page Performance Test - https://www.webpagetest.org/
 - GTMetrix	https://gtmetrix.com/
+- Website Speed Comparison - https://landing-five-dusky-44.vercel.app/comparar-velocidad - Compare your site's PageSpeed score vs. a competitor's using real Google PageSpeed Insights data
 
 ### Web Scraping Tools
 - Import.io - https://www.import.io/


### PR DESCRIPTION
## Description

Adding a free tool to the Site Performance Tools section.

### Tool added:

**[Website Speed Comparison](https://landing-five-dusky-44.vercel.app/comparar-velocidad)** — Free tool to compare your website's PageSpeed score against a competitor's side by side, using real Google PageSpeed Insights data. Unlike single-site tools, this lets you benchmark against the competition without any signup.

Fits naturally after the existing PageSpeed and GTMetrix entries.