### PR TITLE
Add Knocket to Customer Support/Live Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - WhatsApp for Business - https://business.whatsapp.com
 - LiveChat - https://www.livechat.com
 - Tawk.to - https://www.tawk.to
+- Knocket - https://trtc.io/solutions/knocket - Free-forever contact layer for indie developers and small teams. Live chat widget for websites and mobile apps (iOS/Android/Flutter/React Native via WebView), a shareable contact page, and a unified Telegram/email inbox. No ads, no seat limits.
 
 ### Social Media
 - Facebook - https://facebook.com


### PR DESCRIPTION
Adding [Knocket](https://trtc.io/solutions/knocket) to the **Customer Support/Live Chat** section.

## What Knocket is

A free-forever contact layer for indie developers and small teams:
- Live chat widget for websites (one-line script tag)
- Mobile Widget for iOS / Android / Flutter / React Native (via WebView)
- Shareable contact page (Linktree-style with socials, booking links, and blog)
- Unified inbox for Live Chat, Telegram, and Email
- Reply directly from Telegram — no dashboard needed

## Free tier scope

100% free forever. No paid tier. No ads. No seat limits.

## Fit with the section

The section already includes free tools like Tawk.to. Knocket serves the same audience — indie founders and small teams — with an emphasis on the earliest stage (finding your first 100 users) and mobile app support.

Disclosure: I'm on the Knocket team.