### PR TITLE
Add Postlia to Sales & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Buffer App - https://buffer.com
 - HootSuite - https://hootsuite.com
 - CrowdFire - https://www.crowdfireapp.com
+- Postlia - https://postlia.com
 - Ubersuggest - https://ubersuggest.org
 - Visual Website Optimizer - https://visualwebsiteoptimizer.com
 - Tweriod - https://www.tweriod.com


### PR DESCRIPTION
Adds **Postlia** (https://postlia.com) to the Sales & Marketing list, next to the other social schedulers (Buffer, HootSuite, CrowdFire).

Postlia is a write-once, publish-everywhere social media scheduler covering LinkedIn, Bluesky, TikTok, Instagram, Pinterest and YouTube Shorts, plus 25+ free social tools. Single line added, matching the existing `- Name - url` format. Thanks for maintaining the list!