### PR TITLE
Add Scribo under Accounting & Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ This is a curated list about tools for everything from productivity to hosting t
 ### Accounting & Finance
 - Wave Apps - https://www.waveapps.com
 - Odoo Accounting - https://www.odoo.com/app/accounting
+- Scribo - https://scribo.causaprima.ai
 
 ### CRM:
 - HubSpot CRM - https://www.hubspot.com/products/crm


### PR DESCRIPTION
Adds **Scribo** to the **Accounting & Finance** section.

Scribo is a free-forever e-invoicing tool hosted on its own domain (https://scribo.causaprima.ai). Describe an invoice in plain language and it generates a compliant document — EN 16931 formats for the EU (German ZUGFeRD & XRechnung live) and plain PDFs for the US. No signup or credit card; the sender's email is the login.

Listed on its custom domain per the contribution standard. Built by Causa Prima (https://causaprima.ai).