### PR TITLE
Add Dealboard to the CRM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Bitrix24 (CRM version) - https://www.bitrix24.com/tools/crm/
 - Google Contacts (can be used as lightweight CRM) - https://contacts.google.com
 - Attio - https://attio.com/
+- Dealboard (visual deal tracker, lighter than a full CRM) - https://getdealboard.com
 
 ### Team Chat & Communication
 - Slack - https://slack.com


### PR DESCRIPTION
Adds **Dealboard** to the CRM list.

Dealboard is a visual deal tracker for founders and small sales/BD teams — a drag-and-drop pipeline with timestamped notes and built-in reports. It sits deliberately lighter than a full CRM (no contact database, no email sequences, no setup project), which is why the entry is labelled that way rather than as a straight CRM.

Relevant for this list: free tier includes 30 active deals and unlimited teammates, so a startup can run its whole pipeline at no cost. Also ships a REST API, webhooks, Zapier/Slack, and an MCP server.

https://getdealboard.com

Single-line addition, existing format followed.