### PR TITLE
Add OpenPost to sales and marketing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ This is a curated list about tools for everything from productivity to hosting t
   - Website Grader - https://grader.com
 - Buffer App - https://buffer.com
 - HootSuite - https://hootsuite.com
+- OpenPost - https://openpost.social
 - CrowdFire - https://www.crowdfireapp.com
 - Ubersuggest - https://ubersuggest.org
 - Visual Website Optimizer - https://visualwebsiteoptimizer.com


### PR DESCRIPTION
Adds OpenPost to the Sales & Marketing section beside the existing social scheduling tools.

Disclosure: I maintain OpenPost.