### PR TITLE
Add GPTGeminiGrok.AI to AI Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Claude - https://claude.ai
 - ChatGPT - https://chatgpt.com
 - Google Gemini - https://gemini.google.com
+- GPTGeminiGrok.AI - https://trygrokai.asia/
 - Grok - https://grok.com
 - Microsoft CoPilot - https://copilot.microsoft.com
 - Kimi - https://www.kimi.com


### PR DESCRIPTION
## Summary

Adds GPTGeminiGrok.AI to the Artificial Intelligence (AI) Chat section.

GPTGeminiGrok.AI is a browser workspace for GPT, Gemini, Grok, Claude, and AI image workflows. It is hosted on a custom domain and offers 10 free requests per day after account registration.

## Disclosure

I am the project operator and am submitting my own service.