### PR TITLE
Add Video Size Reducer to Video making section

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Good for team projects
 - Openshot - https://www.openshot.org
 - Video captions - https://subsvideo.com
 - VEED - https://www.veed.io
+- Video Size Reducer - https://videosizereducer.org
 - Tavus (AI based) - https://www.tavus.io
 
 ### Stock Photos/Illustrations/Icons:


### PR DESCRIPTION
Adds Video Size Reducer (https://videosizereducer.org) to the Video making section, alongside the other browser video tools (VEED etc.).

It's a free browser-based MP4 compressor using the WebCodecs API — processing happens locally in the browser, no upload or account required. Useful for shrinking demo/marketing videos before publishing.

Single-line addition following the existing 'Name - url' format.