### PR TITLE
Add Dealboard to the CRM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Bitrix24 (CRM version) - https://www.bitrix24.com/tools/crm/
 - Google Contacts (can be used as lightweight CRM) - https://contacts.google.com
 - Attio - https://attio.com/
+- Dealboard (visual deal tracker, lighter than a full CRM) - https://getdealboard.com
 
 ### Team Chat & Communication
 - Slack - https://slack.com

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ This is a curated list about tools for everything from productivity to hosting t
 - Bitrix24 (CRM version) - https://www.bitrix24.com/tools/crm/
 - Google Contacts (can be used as lightweight CRM) - https://contacts.google.com
 - Attio - https://attio.com/
-- Dealboard (visual deal tracker, lighter than a full CRM) - https://getdealboard.com
+- Dealboard - https://getdealboard.com
 
 ### Team Chat & Communication
 - Slack - https://slack.com


### PR DESCRIPTION
Adds Dealboard to the CRM list.

Re-opening the contribution from #213 (which was closed) with the change @mjawaids requested — the description has been removed so the entry follows the plain list format:

`- Dealboard - https://getdealboard.com`

Thanks for the review! 🙏