### PR TITLE
Add Klinky

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ This is a curated list of tools for everything from productivity to hosting to d
 - PostHog - https://posthog.com
 - OptimalUX - https://optimalux.com
 - Upflowy - https://www.upflowy.com
+- Klinky - https://klinky.io
 
 ### Blogging, Writing:
 - Substack - https://substack.com


### PR DESCRIPTION
Adds Klinky (https://klinky.io) to the Web Experimentation section, alongside VWO and PostHog.

Klinky is an A/B testing link shortener: one short link splits traffic between two destinations at configurable weights, and every click is tracked so you can compare variants with real data. It works at the link level — no JavaScript snippet to install — which makes it a lightweight way to test landing pages or offers. Free plan available, hosted on its own domain.
