### PR TITLE
docs: add WeekLife

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Good for team projects
 - Paymo - https://www.paymoapp.com
 - Jibble - https://www.jibble.io
 - Connecteam - https://connecteam.com/employee-time-clock-app/employee-time-tracking-app/
+- [WeekLife](https://letmethink.cc/app/weeklife/) - A lightweight life check-in tool for reclaiming everyday life beyond work.
 
 ## Productivity Techniques
 - Pomodoro Technique - https://en.wikipedia.org/wiki/Pomodoro_Technique

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ This is a curated list of tools for everything from productivity to hosting to d
 
 ### Journaling:
 - DailyWins - https://dailywins.ibexoft.com
+- WeekLife - https://letmethink.cc/app/weeklife/
 
 ### Documentation & Collaboration
 - Atlassian Confluence - https://www.atlassian.com/software/confluence
@@ -343,7 +344,6 @@ Good for team projects
 - Paymo - https://www.paymoapp.com
 - Jibble - https://www.jibble.io
 - Connecteam - https://connecteam.com/employee-time-clock-app/employee-time-tracking-app/
-- [WeekLife](https://letmethink.cc/app/weeklife/) - A lightweight life check-in tool for reclaiming everyday life beyond work.
 
 ## Productivity Techniques
 - Pomodoro Technique - https://en.wikipedia.org/wiki/Pomodoro_Technique


### PR DESCRIPTION
Hi! I'd like to suggest adding WeekLife to this list.

- [WeekLife](https://letmethink.cc/app/weeklife/) — A lightweight life check-in tool designed to help people reclaim their weekdays.

I reviewed the list and believe this project fit the selected section. Happy to adjust the wording or placement to match the maintainers' preference.

Thanks for maintaining this resource.