### PR TITLE
Add Granite to Cloud and Traditional Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This is a curated list of tools for everything from productivity to hosting to d
 - Digital Ocean - https://digitalocean.com
 - Render - https://render.com
 - Vultr - https://www.vultr.com/free-tier-program/
+- Granite - https://granite.so
 
 #### Static Site Hosting:
 - CloudFlare Pages - https://pages.cloudflare.com


### PR DESCRIPTION

Adds Granite to `### Cloud and Traditional Hosting:`.

```
- Granite - https://granite.so
```

### What it is

A managed platform for running web applications: deploy from a Git repository or any Docker image, with managed PostgreSQL, MySQL, MongoDB and Valkey, S3-compatible object storage with a CDN, and a private Docker registry alongside. Plans start at $9/month.

For a startup picking hosting, it sits between the raw infrastructure already listed here (AWS, Azure, Google Cloud, DigitalOcean, Vultr) and the managed end of the list — closest in shape to Render, which is already included.

### Formatting

- Plain `- Name - URL`, matching the rest of the section rather than markdown links.
- Appended after Vultr, since the section is not alphabetically ordered.

### Disclosure

I work on Granite, so this is a self-submission. Flagging it up front.

This PR was assisted by AI (Claude) for research and drafting; the claims are mine and are verifiable at https://granite.so.
