### PR TITLE
Add sms-florin to Notification (Push, SMS etc) Service for Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ This is a curated list of tools for everything from productivity to hosting to d
 - OneSignal - https://onesignal.com
 - Pusher - https://pusher.com
 - Twilio - https://www.twilio.com
+- sms-florin - https://flo-voice1.com (real UK phone numbers for receiving SMS/OTP during signup and verification testing, with a REST API and npm SDK for QA/CI automation)
 
 ### Changelog
 - Headway - https://headwayapp.co/


### PR DESCRIPTION
Adding [sms-florin](https://flo-voice1.com) to the Notification / SMS services section, alongside Twilio and Pusher.

sms-florin rents real UK phone numbers (physical SIM cards on EE/Three networks) for receiving SMS/OTP verification codes — useful when testing signup and 2FA flows for apps like WhatsApp, Telegram, Google, and Discord without tying up a personal number. It also ships a public REST API and an [npm SDK](https://www.npmjs.com/package/sms-florin) aimed at QA/CI test-automation use cases.

Custom domain, no GitHub-repo-as-product or platform-subdomain link, live product with paid usage.