### PR TITLE
Update Mailtrap entry — remove "testing only" framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ This is a curated list of tools for everything from productivity to hosting to d
 - ForwardEmail - https://forwardemail.net/
 - MX Toolbox - https://mxtoolbox.com/SuperTool.aspx
 - DMarcian - https://dmarcian.com/dmarc-tools/
-- Mail Trap (for testing only) - https://mailtrap.io/
+- Mailtrap - https://mailtrap.io/
 - Email Validation API - https://www.abstractapi.com/email-verification-validation-api
 
 ### Notification (Push, SMS etc) Service for Developers


### PR DESCRIPTION
Mailtrap is listed as "for testing only," but it's also a full email sending API/SMTP platform for transactional and bulk email (free tier: 4,000 emails/month). This updates the entry to reflect that broader use case, consistent with how other entries in this section (Resend, Mailgun, SendGrid) are listed without a use-case caveat.