### PR TITLE
Add Autoposting to Social Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ This is a curated list of tools for everything from productivity to hosting to d
 - Threads - https://www.threads.com
 - Mastodon - https://joinmastodon.org
 - Bluesky - https://bsky.app
+- Autoposting - https://autoposting.ai
 
 ### Sales & Marketing:
 - HubSpot - https://www.hubspot.com


### PR DESCRIPTION
Adds Autoposting under Business, Marketing, Sales, Finance → Social Media.

AI social media manager: writes posts in your own voice, clips long video into short-form, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube. Free tier available.

One line added, plain `- Name - url` style matching the section.