### PR TITLE
Add Backscroll to Note-taking & Reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ This is a curated list of tools for everything from productivity to hosting to d
 - Google Keep - https://keep.google.com
 - Capacities - https://capacities.io
 - Obsidian - https://obsidian.md
+- Backscroll - https://backscroll.xyz (imports and makes searchable your ChatGPT/Claude/Gemini chat history)
 
 ### Journaling:
 - DailyWins - https://dailywins.ibexoft.com


### PR DESCRIPTION
Adds Backscroll (https://backscroll.xyz) — custom domain, live Stripe billing ($6/mo, $29 founding-year), not a GitHub-repo link or platform subdomain, per the editorial note at the top of the list. It imports and makes searchable your ChatGPT/Claude/Gemini chat history.