### PR TITLE
Add Mentioned under Sales & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ This is a curated list of tools for everything from productivity to hosting to d
 - HootSuite - https://hootsuite.com
 - CrowdFire - https://www.crowdfireapp.com
 - Ubersuggest - https://ubersuggest.org
+- Mentioned (managed Reddit growth for SEO) - https://mentioned.to
 - Visual Website Optimizer - https://visualwebsiteoptimizer.com
 - Tweriod - https://www.tweriod.com
 - My Site Auditor - https://mysiteauditor.com


### PR DESCRIPTION
Adds [Mentioned](https://mentioned.to) to *Business, Marketing, Sales, Finance > Sales & Marketing*, matching the existing plain `Name - URL` format.

Reddit threads rank for a lot of high-intent queries and are heavily cited by AI answer engines, but nothing in the list covers that surface. Mentioned is a managed service: it finds the Reddit threads already ranking on Google for a startup's keywords, places the brand in them, and reports share of voice against competitors.

One line added, no other changes.