### PR TITLE
Add Reloop to email service for developers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This is a curated list of tools for everything from productivity to hosting to d
 - Code Climate - https://codeclimate.com
 
 ### Email Service for Developers
+- Reloop - https://reloop.sh
 - Resend - https://resend.com/
 - Brevo (Ex Sendinblue) - https://www.brevo.com/
 - MailGun - https://www.mailgun.com , https://www.mailgun.com/google


### PR DESCRIPTION
**What is Reloop?**

Reloop is a transactional email API and SMTP service built for developers and AI agents.

**What does this PR add?**

Adds Reloop to the outgoing email services list as a modern alternative to Resend — specifically built for developers who are building AI-native applications.

**Why Reloop?**

Simple API — plug and send, no unnecessary setup
Built for AI agents and automated workflows
Reliable open-loop email infrastructure
SMTP support for developers who prefer it

**Links**
Website: https://reloop.sh
Docs: https://reloop.sh/docs