### PR TITLE
Add videos.social to Video making

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Good for team projects
 - Video captions - https://subsvideo.com
 - VEED - https://www.veed.io
 - Tavus (AI based) - https://www.tavus.io
+- videos.social (AI based) - https://videos.social/?utm_source=ibexoft-awesome-startup-tools-list&utm_medium=directory&utm_campaign=listing-wave-d
 
 ### Stock Photos/Illustrations/Icons:
 - Unsplash - https://unsplash.com


### PR DESCRIPTION
Adds videos.social next to VEED / Tavus in Video making.

videos.social turns blogs, PDFs, and prompts into editable faceless videos (script, scenes, voiceover) rather than a locked regenerate loop. Start free — 1 render included. Packs from $10. 1 credit = 1 render.

Public, usable product in the same class as Pictory / Descript / VEED. Not a duplicate.

Disclosure: submitted by the videos.social team.