### PR TITLE
Add Tabox (browser tab management)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ This is a curated list of tools for everything from productivity to hosting to d
 ### Journaling:
 - DailyWins - https://dailywins.ibexoft.com
 
+### Browser Tab Management:
+- Tabox - https://www.tabox.co
+
 ### Documentation & Collaboration
 - Atlassian Confluence - https://www.atlassian.com/software/confluence
 - Microsoft Loop - https://www.microsoft.com/en-us/microsoft-loop


### PR DESCRIPTION
Adds a small Browser Tab Management subsection under Productivity with [Tabox](https://www.tabox.co) — a free, open-source extension that saves tabs and tab groups into collections and restores whole sessions in one click. Useful for keeping per-project browser contexts when wearing many hats at a startup. Open source: https://github.com/gilgold/tabox

Disclosure: I'm the developer of Tabox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)