### PR TITLE
Add Zapier under a new Automation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ This is a curated list of tools for everything from productivity to hosting to d
 - Attio - https://attio.com/
 - Dealboard - https://getdealboard.com
 
+### Automation
+- Zapier - https://zapier.com
+
 ### Team Chat & Communication
 - Slack - https://slack.com
 - Microsoft Teams - https://teams.microsoft.com


### PR DESCRIPTION
The list doesn't currently have an automation/workflow category, and Zapier (or any similar tool — Make, n8n, etc.) isn't listed anywhere. Adding a small "Automation" section under Business/Marketing/Sales/Finance, alongside CRM and Team Chat.

Zapier offers a permanent free plan (100 tasks/month), so it fits the "must have a permanently usable free tier" criteria in the contributing note at the top of the README.