### PR TITLE
Add Seller Calculators to Accounting & Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ This is a curated list of tools for everything from productivity to hosting to d
 ### Accounting & Finance
 - Wave Apps - https://www.waveapps.com
 - Odoo Accounting - https://www.odoo.com/app/accounting
+- Seller Calculators - https://sellercalculators.com
 
 ### CRM:
 - HubSpot CRM - https://www.hubspot.com/products/crm


### PR DESCRIPTION
Hi there! 

I've added Seller Calculators (https://sellercalculators.com) to the Accounting & Finance section. 

It is a permanently free web utility (no paywalls, sign-up required, or trial limits) featuring interactive fee and profit margin calculators for e-commerce merchants selling on Etsy, Shopify, and Amazon.

Thanks for maintaining this list!